### PR TITLE
feat: use iterator of str to accept more input types

### DIFF
--- a/demo/src/app.rs
+++ b/demo/src/app.rs
@@ -68,12 +68,7 @@ impl AutoCompleteExample {
         max_suggestions: usize,
         highlight_matches: bool,
     ) {
-        let inputs: Vec<&str> = self
-            .multi_input
-            .lines()
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        let inputs = self.multi_input.lines().collect::<BTreeSet<_>>();
         ui.add(
             AutoCompleteTextEdit::new(&mut self.search_field, inputs)
                 .max_suggestions(max_suggestions)

--- a/demo/src/app.rs
+++ b/demo/src/app.rs
@@ -68,15 +68,14 @@ impl AutoCompleteExample {
         max_suggestions: usize,
         highlight_matches: bool,
     ) {
-        let inputs: Vec<String> = self
+        let inputs: Vec<&str> = self
             .multi_input
             .lines()
-            .map(|x| x.to_string())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
         ui.add(
-            AutoCompleteTextEdit::new(&mut self.search_field, &inputs)
+            AutoCompleteTextEdit::new(&mut self.search_field, inputs)
                 .max_suggestions(max_suggestions)
                 .highlight_matches(highlight_matches),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,12 @@ use std::cmp::{min, Reverse};
 /// Trait that can be used to modify the TextEdit
 type SetTextEditProperties = dyn FnOnce(TextEdit) -> TextEdit;
 
-/// An extension to the [`egui::TextEdit`] that allows for a dropdown box with autocomplete to popup while typing.  
-pub struct AutoCompleteTextEdit<'a> {
+/// An extension to the [`egui::TextEdit`] that allows for a dropdown box with autocomplete to popup while typing.
+pub struct AutoCompleteTextEdit<'a, T> {
     /// Contents of text edit passed into [`egui::TextEdit`]
     text_field: &'a mut String,
     /// Slice of strings to use as the search term
-    search: &'a [String],
+    search: T,
     /// A limit that can be placed on the maximum number of autocomplete suggestions shown
     max_suggestions: usize,
     /// If true, highlights the macthing indices in the dropdown
@@ -42,12 +42,15 @@ pub struct AutoCompleteTextEdit<'a> {
     set_properties: Option<Box<SetTextEditProperties>>,
 }
 
-impl<'a> AutoCompleteTextEdit<'a> {
+impl<'a, T> AutoCompleteTextEdit<'a, T>
+where
+    T: IntoIterator<Item = &'a str>,
+{
     /// Creates a new [`AutoCompleteTextEdit`].
     ///
     /// `text_field` - Contents of the text edit passed into [`egui::TextEdit`]
     /// `search` - Slice of strings to use as the search term
-    pub fn new(text_field: &'a mut String, search: &'a [String]) -> Self {
+    pub fn new(text_field: &'a mut String, search: T) -> Self {
         Self {
             text_field,
             search,
@@ -58,7 +61,10 @@ impl<'a> AutoCompleteTextEdit<'a> {
     }
 }
 
-impl<'a> AutoCompleteTextEdit<'a> {
+impl<'a, T> AutoCompleteTextEdit<'a, T>
+where
+    T: IntoIterator<Item = &'a str>,
+{
     /// This determines the number of options appear in the dropdown menu
     pub fn max_suggestions(mut self, max_suggestions: usize) -> Self {
         self.max_suggestions = max_suggestions;
@@ -92,7 +98,10 @@ impl<'a> AutoCompleteTextEdit<'a> {
     }
 }
 
-impl<'a> Widget for AutoCompleteTextEdit<'a> {
+impl<'a, T> Widget for AutoCompleteTextEdit<'a, T>
+where
+    T: IntoIterator<Item = &'a str>,
+{
     /// The response returned is the response from the internal text_edit
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
         let Self {
@@ -125,7 +134,7 @@ impl<'a> Widget for AutoCompleteTextEdit<'a> {
         let matcher = SkimMatcherV2::default().ignore_case();
 
         let mut match_results = search
-            .iter()
+            .into_iter()
             .filter_map(|s| {
                 let score = matcher.fuzzy_indices(s, text_field.as_str());
                 score.map(|(score, indices)| (s, score, indices))
@@ -199,7 +208,7 @@ impl<'a> Widget for AutoCompleteTextEdit<'a> {
 }
 
 /// Highlights all the match indices in the provided text
-fn highlight_matches(text: &&String, match_indices: &[usize], color: egui::Color32) -> LayoutJob {
+fn highlight_matches(text: &str, match_indices: &[usize], color: egui::Color32) -> LayoutJob {
     let mut formatted = LayoutJob::default();
     let mut it = (0..text.len()).peekable();
     // Iterate through all indices in the string
@@ -324,7 +333,7 @@ mod test {
     fn highlight() {
         let text = String::from("Test123");
         let match_indices = vec![1, 5, 6];
-        let layout = highlight_matches(&&text, &match_indices, egui::Color32::RED);
+        let layout = highlight_matches(&text, &match_indices, egui::Color32::RED);
         assert_eq!(4, layout.sections.len());
         let sec1 = layout.sections.get(0).unwrap();
         assert_eq!(sec1.byte_range, 0..1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,10 @@ pub struct AutoCompleteTextEdit<'a, T> {
     set_properties: Option<Box<SetTextEditProperties>>,
 }
 
-impl<'a, T> AutoCompleteTextEdit<'a, T>
+impl<'a, T, S> AutoCompleteTextEdit<'a, T>
 where
-    T: IntoIterator<Item = &'a str>,
+    T: IntoIterator<Item = S>,
+    S: AsRef<str>,
 {
     /// Creates a new [`AutoCompleteTextEdit`].
     ///
@@ -61,9 +62,10 @@ where
     }
 }
 
-impl<'a, T> AutoCompleteTextEdit<'a, T>
+impl<'a, T, S> AutoCompleteTextEdit<'a, T>
 where
-    T: IntoIterator<Item = &'a str>,
+    T: IntoIterator<Item = S>,
+    S: AsRef<str>,
 {
     /// This determines the number of options appear in the dropdown menu
     pub fn max_suggestions(mut self, max_suggestions: usize) -> Self {
@@ -98,9 +100,10 @@ where
     }
 }
 
-impl<'a, T> Widget for AutoCompleteTextEdit<'a, T>
+impl<'a, T, S> Widget for AutoCompleteTextEdit<'a, T>
 where
-    T: IntoIterator<Item = &'a str>,
+    T: IntoIterator<Item = S>,
+    S: AsRef<str>,
 {
     /// The response returned is the response from the internal text_edit
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
@@ -136,7 +139,7 @@ where
         let mut match_results = search
             .into_iter()
             .filter_map(|s| {
-                let score = matcher.fuzzy_indices(s, text_field.as_str());
+                let score = matcher.fuzzy_indices(s.as_ref(), text_field.as_str());
                 score.map(|(score, indices)| (s, score, indices))
             })
             .collect::<Vec<_>>();
@@ -162,7 +165,7 @@ where
             state.selected_index,
             ui.memory(|mem| mem.is_popup_open(id)) && accepted_by_keyboard,
         ) {
-            text_field.replace(match_results[index].0)
+            text_field.replace(match_results[index].0.as_ref())
         }
         egui::popup::popup_below_widget(ui, id, &text_response, |ui| {
             for (i, (output, _, match_indices)) in
@@ -176,17 +179,17 @@ where
 
                 let text = if highlight {
                     highlight_matches(
-                        output,
+                        output.as_ref(),
                         match_indices,
                         ui.style().visuals.widgets.active.text_color(),
                     )
                 } else {
                     let mut job = LayoutJob::default();
-                    job.append(output, 0.0, egui::TextFormat::default());
+                    job.append(output.as_ref(), 0.0, egui::TextFormat::default());
                     job
                 };
                 if ui.toggle_value(&mut selected, text).clicked() {
-                    text_field.replace(output);
+                    text_field.replace(output.as_ref());
                 }
             }
         });


### PR DESCRIPTION
Hi, thank you for this useful crate. I am trying to use this crate in my project and make some changes, which might be also useful for others. 

Basically, I change the `search` field type from `&'a [String]` to `impl IntoIterator<Item=impl AsRef<str>>`. The benefit is that: 

1. It can accept more types now. The usual way to get a slice is from a `Vec` or an array, but now any iterators can be used. 
2. It saves the cost of string allocation. It is cheap to convert from a `String` to a `&str`, but is expensive to do the opposite. Using an `AsRef<str>` allows `String`, `str` and `Cow<'_, str>` to be used as input, and provides more optimization space for the user. 

In my case, I want to match the keys in the `HashMap<String, T>`, and with this change, I can easily pass `HashMap::keys()` to the widget, without the need to collect into a `Vec`. This is also reflected in the demo's `app.rs` change where a `BTreeSet<&str>` is passed as input. 