### PR TITLE
remove eframe from lib dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,6 @@ dependencies = [
 name = "egui_autocomplete"
 version = "7.0.0"
 dependencies = [
- "eframe",
  "egui",
  "fuzzy-matcher",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.76"
 fuzzy-matcher = "0.3.7"
 serde = { version = "1", features = ["derive"], optional = true }
 egui.workspace = true
-eframe.workspace = true
 
 [workspace]
 members = ["demo"]


### PR DESCRIPTION
I removed eframe from dependencies of the library, as it is only needed for demo app.